### PR TITLE
Audiolog import/export

### DIFF
--- a/plugins.csv
+++ b/plugins.csv
@@ -10,3 +10,5 @@ Name,Version,Category,Description,Repository,Commit
 "googlecalendar","1.1.0","speechhandler","Set and retrieve events from your Google calendar","https://github.com/aaronchantrill/Naomi-Google-Calendar.git","31bc380"
 "Respeaker 4Mic Volume","1.0.0","visualizations","LED Display for SeeedStudio Respeaker","https://github.com/aaronchantrill/respeaker_4mic_volume.git","c8904e8"
 "You're Welcome","0.0.1","speechhandler","Answers ""Thank you"" with ""You're welcome""","https://github.com/aaronchantrill/YoureWelcome.git","3885b71"
+"Archive Audiolog","1.0.0","stt_trainer","Allows the user to export their audiolog database and audio files into an archive file that can be merged into a different Naomi using the Import Audiolog plugin.","https://github.com/aaronchantrill/archive_audiolog.git","dfdb74b"
+"Import Audiolog","1.0.0","stt_trainer","Allows the user to import and merge an audiolog archive created by the Archive Audiolog plugin.","https://github.com/aaronchantrill/import_audiolog.git","e7fb27c"

--- a/plugins.csv
+++ b/plugins.csv
@@ -1,4 +1,5 @@
 Name,Version,Category,Description,Repository,Commit
+"Archive Audiolog","1.0.0","stt_trainer","Allows the user to export their audiolog database and audio files into an archive file that can be merged into a different Naomi using the Import Audiolog plugin.","https://github.com/aaronchantrill/archive_audiolog.git","dfdb74b"
 "Chuck Norris Jokes","1.0.0","speechhandler","Have Naomi tell random Chuck Norris Jokes","https://github.com/austincasteel/chucknorrisjokes.git","63447cf"
 "Control LED","1.0.2","speechhandler","A simple module that combines Naomi and the Arduino platform to show possibilities in IOT and new interactions.","https://github.com/NaomiProject/controlLED-plugin.git","340598e"
 "Dad Jokes","1.0.0","speechhandler","Have Naomi tell Dad Jokes","https://github.com/austincasteel/dadjokes.git","ca358fa"
@@ -8,7 +9,6 @@ Name,Version,Category,Description,Repository,Commit
 "frotz","0.1.0","speechhandler","Would you like to play a game?","https://github.com/aaronchantrill/NaomiFrotz.git","a8c0ce0"
 "Google AIY Voice V1 Visualizations","1.0.0","visualizations","Visualizations of Naomi's internal state for the Google AIY Voice V1 kit","https://github.com/aaronchantrill/Naomi_Google_AIY_Voice_v1_Button.git","5dfb568"
 "googlecalendar","1.1.0","speechhandler","Set and retrieve events from your Google calendar","https://github.com/aaronchantrill/Naomi-Google-Calendar.git","31bc380"
+"Import Audiolog","1.0.0","stt_trainer","Allows the user to import and merge an audiolog archive created by the Archive Audiolog plugin.","https://github.com/aaronchantrill/import_audiolog.git","e7fb27c"
 "Respeaker 4Mic Volume","1.0.0","visualizations","LED Display for SeeedStudio Respeaker","https://github.com/aaronchantrill/respeaker_4mic_volume.git","c8904e8"
 "You're Welcome","0.0.1","speechhandler","Answers ""Thank you"" with ""You're welcome""","https://github.com/aaronchantrill/YoureWelcome.git","3885b71"
-"Archive Audiolog","1.0.0","stt_trainer","Allows the user to export their audiolog database and audio files into an archive file that can be merged into a different Naomi using the Import Audiolog plugin.","https://github.com/aaronchantrill/archive_audiolog.git","dfdb74b"
-"Import Audiolog","1.0.0","stt_trainer","Allows the user to import and merge an audiolog archive created by the Archive Audiolog plugin.","https://github.com/aaronchantrill/import_audiolog.git","e7fb27c"


### PR DESCRIPTION
Added two new stt_trainer plugins that can be used to export the
database and audio files from an audiolog and merge it into the
audiolog database on a different machine, allowing different
naomi's to be trained to your voice.